### PR TITLE
fix: npm publish registry config and release v1.2.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,8 +1,5 @@
-# For GitHub Packages
-@open-templates:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-
-# For NPM registry (default)
-# Note: For GitHub Actions, Trusted Publishing is used (no token needed)
-# For local publishing, configure npm login: npm login
+# npm registry (default for installs and publishing)
 registry=https://registry.npmjs.org/
+
+# Per-registry publish targets are set in package.json publishConfig by each CI job.
+# Do not add @scope:registry here — it overrides publishConfig and breaks dual publishing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-07-03
+
+### Fixed
+
+- Corrected `.npmrc` so scoped packages no longer route to the wrong registry during publish
+- Added explicit `publishConfig.registry` for npm publishing
+- Regenerated `package-lock.json` to fix `npm ci` sync errors
+
 ## [1.2.0] - 2026-07-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-package-template",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-package-template",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-package-template",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A modern TypeScript npm package template with automated publishing, testing, and tooling",
   "type": "module",
   "sideEffects": false,
@@ -48,7 +48,8 @@
     "url": "git+https://github.com/open-templates/npm-package-template.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "homepage": "https://github.com/open-templates/npm-package-template#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

Patch release **v1.2.1** fixing npm publish failures caused by incorrect registry routing.

- Removed `@open-templates:registry` from `.npmrc` — it was sending scoped publishes to GitHub Packages during the npm job (and would conflict the other way around)
- Added explicit `publishConfig.registry` pointing to `https://registry.npmjs.org` in `package.json`
- Each CI publish job now controls its target registry via `publishConfig` (`publish-npm` → npm, `publish-github` → GitHub Packages)
- Bumped version to **1.2.1** and documented changes in `CHANGELOG.md`

## Test plan

- [x] `npm ci` passes
- [x] `npm run check` passes
- [ ] Merge to `main` and create GitHub release `v1.2.1`
- [ ] Verify `publish-npm` publishes `@open-templates/npm-package-template` to registry.npmjs.org
- [ ] Verify `publish-github` still publishes to GitHub Packages